### PR TITLE
Remove unnecessary env searching

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -8,14 +8,12 @@ import (
 )
 
 func Env(key, def string) string {
-	var val string
-	val = os.Getenv(key)
 	val, set := os.LookupEnv(key)
 	if set {
 		return val
-	} else {
-		return def
 	}
+
+	return def
 }
 
 func BoolEnv(key, def string) bool {

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"testing"
+	"os"
+)
+
+func TestEnv_ExistingValue(t *testing.T) {
+	key := "TEST_KEY"
+	value := "TEST_VALUE"
+
+	os.Setenv(key, value)
+	defer os.Unsetenv(key)
+
+	res := Env(key, "default")
+	if res != value {
+		t.Errorf("I expected to get \"%s\" but got \"%s\"", value, res)
+	}
+}
+
+func TestEnv_NotExistingValue(t *testing.T) {
+	key := "TEST_KEY"
+	def := "DEFAULT"
+
+	res := Env(key, def)
+	if res != def {
+		t.Errorf("I expected to get \"%s\" but got \"%s\"", def, res)
+	}
+}


### PR DESCRIPTION
Here I removed unnecessary getting of env variable

We have two methods in `os` package:

```go
// Getenv retrieves the value of the environment variable named by the key.
// It returns the value, which will be empty if the variable is not present.
// To distinguish between an empty value and an unset value, use LookupEnv.
func Getenv(key string) string {
	v, _ := syscall.Getenv(key)
	return v
}

// LookupEnv retrieves the value of the environment variable named
// by the key. If the variable is present in the environment the
// value (which may be empty) is returned and the boolean is true.
// Otherwise the returned value will be empty and the boolean will
// be false.
func LookupEnv(key string) (string, bool) {
	return syscall.Getenv(key)
}
```

As we can see, that methods are same, but `GetEnv()` ignores error and returns default value for type `string`.