### PR TITLE
Refactoring of BoolEnv()

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -2,7 +2,8 @@ package common
 
 import (
 	"os"
-	"strings"
+
+	"strconv"
 
 	"github.com/microcosm-cc/bluemonday"
 )
@@ -18,11 +19,16 @@ func Env(key, def string) string {
 
 func BoolEnv(key string, def bool) bool {
 	val, set := os.LookupEnv(key)
-	if set {
-		return strings.ToLower(val) == "true"
+	if !set {
+		return def
 	}
 
-	return def
+	boolVal, err := strconv.ParseBool(val)
+	if err != nil {
+		return def
+	}
+
+	return boolVal
 }
 
 func FilterHtml(html string) string {

--- a/common/util.go
+++ b/common/util.go
@@ -16,10 +16,13 @@ func Env(key, def string) string {
 	return def
 }
 
-func BoolEnv(key, def string) bool {
-	val := Env(key, def)
-	val = strings.ToLower(val)
-	return val == "true"
+func BoolEnv(key string, def bool) bool {
+	val, set := os.LookupEnv(key)
+	if set {
+		return strings.ToLower(val) == "true"
+	}
+
+	return def
 }
 
 func FilterHtml(html string) string {

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -28,12 +28,20 @@ func TestEnv_NotExistingValue(t *testing.T) {
 	}
 }
 
-func TestBoolEnv_ExistingValue(t *testing.T) {
+func TestBoolEnv_ExistingParsableValue(t *testing.T) {
 	testCases := map[string]bool{
-		"TRUE":  true,
+		"1":     true,
+		"t":     true,
+		"T":     true,
 		"true":  true,
-		"FALSE": false,
+		"True":  true,
+		"TRUE":  true,
+		"0":     false,
+		"f":     false,
+		"F":     false,
 		"false": false,
+		"False": false,
+		"FALSE": false,
 	}
 
 	key := "TEST_KEY"
@@ -48,6 +56,25 @@ func TestBoolEnv_ExistingValue(t *testing.T) {
 
 		os.Unsetenv(key)
 	}
+}
+
+func TestBoolEnv_ExistingUnparsableValue(t *testing.T) {
+	testCases := map[bool]bool{
+		true:  true,
+		false: false,
+	}
+
+	key := "TEST_KEY"
+	os.Setenv(key, "Yes")
+
+	for defValue, expectedValue := range testCases {
+		res := BoolEnv(key, defValue)
+		if res != expectedValue {
+			t.Errorf("I expected to get %v but got %v", expectedValue, res)
+		}
+	}
+
+	os.Unsetenv(key)
 }
 
 func TestBoolEnv_NotExistingValue(t *testing.T) {

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -1,8 +1,8 @@
 package common
 
 import (
-	"testing"
 	"os"
+	"testing"
 )
 
 func TestEnv_ExistingValue(t *testing.T) {
@@ -25,5 +25,43 @@ func TestEnv_NotExistingValue(t *testing.T) {
 	res := Env(key, def)
 	if res != def {
 		t.Errorf("I expected to get \"%s\" but got \"%s\"", def, res)
+	}
+}
+
+func TestBoolEnv_ExistingValue(t *testing.T) {
+	testCases := map[string]bool{
+		"TRUE":  true,
+		"true":  true,
+		"FALSE": false,
+		"false": false,
+	}
+
+	key := "TEST_KEY"
+
+	for envValue, expectedValue := range testCases {
+		os.Setenv(key, envValue)
+
+		res := BoolEnv(key, !expectedValue)
+		if res != expectedValue {
+			t.Errorf("I expected to get %v but got %v", expectedValue, res)
+		}
+
+		os.Unsetenv(key)
+	}
+}
+
+func TestBoolEnv_NotExistingValue(t *testing.T) {
+	testCases := map[bool]bool{
+		true:  true,
+		false: false,
+	}
+
+	key := "TEST_KEY"
+
+	for defValue, expectedValue := range testCases {
+		res := BoolEnv(key, defValue)
+		if res != expectedValue {
+			t.Errorf("I expected to get %v but got %v", expectedValue, res)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func main() {
 
 	if err == nil {
 		defer Db.Close()
-		if BoolEnv("DEBUG", "false") {
+		if BoolEnv("DEBUG", false) {
 			Db.LogMode(true)
 			Db.Debug()
 		}


### PR DESCRIPTION
В этом реквесте я хочу предложить изменение функции `BoolEnv()`. Изначально она принимала два строковых параметра: ключ и значение по-умолчанию. Мне показалось, что при запросе булевой переменной значение по-умолчанию также должно быть булевым, иначе это слегка сбивает с толку. Здесь я изменил сигнатуру функции таким образом, что сейчас мы принимаем в качестве стандартного значения значение булевого типа. Также покрыл функцию тестами.