### PR TITLE
Fix cannot install initial ServerConfig

### DIFF
--- a/common/common/common.go
+++ b/common/common/common.go
@@ -5,6 +5,6 @@ func S2BA(value string) []byte {
 }
 
 type ServerConfig struct {
-	ID           uint `gorm:"primary_key" json:"id"`
-	JwtSignature []byte
+	ID           uint   `gorm:"primary_key" json:"id"`
+	JwtSignature []byte `gorm:"type:varbinary(256)"`
 }


### PR DESCRIPTION
This was because the default col size is 255
which was smaller than the created 256 byte array

I wasn't sure if it was better to change the length of the byte array or make
the DB type explicit.